### PR TITLE
Update xiter to use Go dev instead of the CL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@ xiter
 
 [![Go Reference](https://pkg.go.dev/badge/deedles.dev/xiter.svg)](https://pkg.go.dev/deedles.dev/xiter)
 
-xiter is a very simple implementation of iterator support functions compatible with CL 510541. It is primarily intended to make it easier to play around with that CL and not for actual usage.
+xiter is a very simple implementation of iterator support functions now supported by GOEXPERIMENT=range in the 1.22dev compiler. It is primarily intended to make it easier to play around with that experiment and not for actual usage.
 
-Although the module's functionality is compatible with CL 510541, all of its features should work just fine with an unmodified Go toolchain. If you would like to try it with the CL, you can install it fairly easily by running
+Although the module's functionality is compatible with the new experiment, all of its features should work just fine with a plain Go toolchain. If you would like to try it with the development toolchain, you can install that fairly easily by running
 
 ```bash
 $ go install golang.org/dl/gotip@latest
-$ gotip download 510541
+$ gotip download
+$ GOEXPERIMENT=range gotip ... 
 ```
 
-This will set up the `gotip` command to run the modified toolchain, allowing for `gotip build`, `gotip run`, etc.
+This will set up the `gotip` command to run the development version of go, allowing for `gotip build`, `gotip run`, etc.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module deedles.dev/xiter
 
-go 1.21
+go 1.22

--- a/oldzip_test.go
+++ b/oldzip_test.go
@@ -42,7 +42,7 @@ func oldZip[T1, T2 any](seq1 Seq[T1], seq2 Seq[T2]) Seq[Zipped[T1, T2]] {
 		seq2(oldZipSend(done, c2))
 	}()
 
-	return func(yield func(Zipped[T1, T2]) bool) bool {
+	return func(yield func(Zipped[T1, T2]) bool) {
 		defer close(done)
 
 		var c1hold chan T1
@@ -70,16 +70,16 @@ func oldZip[T1, T2 any](seq1 Seq[T1], seq2 Seq[T2]) Seq[Zipped[T1, T2]] {
 			}
 
 		send: // Dear lord, what is even going on here?
-			if (val.OK1 || (c1 == c1hold)) && (val.OK2 || (c2 == c2hold)) && !(c1==c1hold && c2==c2hold) {
+			if (val.OK1 || (c1 == c1hold)) && (val.OK2 || (c2 == c2hold)) && !(c1 == c1hold && c2 == c2hold) {
 				if !yield(val) {
-					return false
+					return
 				}
 				c1, c1hold, c2, c2hold = c1hold, nil, c2hold, nil
 				val = Zipped[T1, T2]{}
 			}
 
 			if (c1 == c1hold) && (c2 == c2hold) {
-				return false
+				return
 			}
 		}
 	}

--- a/reflect.go
+++ b/reflect.go
@@ -35,13 +35,13 @@ func OfValue(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
 }
 
 func ofValueIndexable(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
-	return func(yield func(v1, v2 reflect.Value) bool) bool {
+	return func(yield func(v1, v2 reflect.Value) bool) {
 		for i := 0; i < v.Len(); i++ {
 			if !yield(reflect.ValueOf(i), v.Index(i)) {
-				return false
+				return
 			}
 		}
-		return false
+		return
 	}
 }
 
@@ -54,36 +54,36 @@ func ofValueString(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
 
 func ofValueChan(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
 	var zero reflect.Value
-	return func(yield func(v1, v2 reflect.Value) bool) bool {
+	return func(yield func(v1, v2 reflect.Value) bool) {
 		for {
 			val, ok := v.Recv()
 			if !ok {
-				return false
+				return
 			}
 			if !yield(val, zero) {
-				return false
+				return
 			}
 		}
 	}
 }
 
 func ofValueMap(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
-	return func(yield func(v1, v2 reflect.Value) bool) bool {
+	return func(yield func(v1, v2 reflect.Value) bool) {
 		iter := v.MapRange()
 		defer iter.Reset(reflect.Value{})
 		for iter.Next() {
 			if !yield(iter.Key(), iter.Value()) {
-				return false
+				return
 			}
 		}
-		return false
+		return
 	}
 }
 
 func ofValuePointerToArray(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
 	sv := v.Elem()
 	if !sv.IsValid() {
-		return func(func(v1, v2 reflect.Value) bool) bool { return false }
+		return func(func(v1, v2 reflect.Value) bool) { return }
 	}
 	return ofValueIndexable(sv)
 }
@@ -93,7 +93,7 @@ func isValueSeq(v reflect.Value) bool {
 	if t.NumIn() != 1 {
 		return false
 	}
-	if t.NumOut()!=1 || t.Out(0).Kind()!=reflect.Bool {
+	if t.NumOut() != 1 || t.Out(0).Kind() != reflect.Bool {
 		return false
 	}
 
@@ -101,10 +101,10 @@ func isValueSeq(v reflect.Value) bool {
 	if yt.Kind() != reflect.Func {
 		return false
 	}
-	if yt.NumIn()!=1 && yt.NumIn()!=2 {
+	if yt.NumIn() != 1 && yt.NumIn() != 2 {
 		return false
 	}
-	if yt.NumOut()!=1 || t.Out(0).Kind()!=reflect.Bool {
+	if yt.NumOut() != 1 || t.Out(0).Kind() != reflect.Bool {
 		return false
 	}
 
@@ -112,7 +112,7 @@ func isValueSeq(v reflect.Value) bool {
 }
 
 func ofValueFunc(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
-	return func(yield func(v1, v2 reflect.Value) bool) bool {
+	return func(yield func(v1, v2 reflect.Value) bool) {
 		yv := reflect.MakeFunc(v.Type().In(0), func(vals []reflect.Value) []reflect.Value {
 			v1, v2 := vals[0], reflect.Value{}
 			if len(vals) == 2 {
@@ -121,13 +121,13 @@ func ofValueFunc(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
 			return []reflect.Value{reflect.ValueOf(yield(v1, v2))}
 		})
 		v.Call([]reflect.Value{yv})
-		return false
+		return
 	}
 }
 
 func ofValueInt(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
 	inc := func(v reflect.Value) reflect.Value { return reflect.ValueOf(v.Int() + 1) }
-	if v.CanInt() && v.Int()<0 {
+	if v.CanInt() && v.Int() < 0 {
 		panic(fmt.Errorf("%v < 0", v.Int()))
 	}
 	if v.CanUint() {
@@ -138,12 +138,12 @@ func ofValueInt(v reflect.Value) Seq2[reflect.Value, reflect.Value] {
 	}
 
 	var zero reflect.Value
-	return func(yield func(v1, v2 reflect.Value) bool) bool {
+	return func(yield func(v1, v2 reflect.Value) bool) {
 		for i := reflect.Zero(v.Type()); i.Interface() != v.Interface(); i = inc(i) {
 			if !yield(i, zero) {
-				return false
+				return
 			}
 		}
-		return false
+		return
 	}
 }

--- a/sink.go
+++ b/sink.go
@@ -96,7 +96,7 @@ func Sum[T Addable](seq Seq[T]) T {
 // Product returns the values of seq multiplied together. It returns
 // 1 if no values are yielded.
 func Product[T Multiplyable](seq Seq[T]) T {
-	return Reduce(seq, 1, func(product, v T) T { return product*v })
+	return Reduce(seq, 1, func(product, v T) T { return product * v })
 }
 
 // IsSorted returns true if each element of seq is greater than or
@@ -201,8 +201,8 @@ func Max[T cmp.Ordered](seq Seq[T]) T {
 
 // FromPair converts a Seq of pairs to a two-value Seq.
 func FromPair[T1, T2 any](seq Seq[Pair[T1, T2]]) Seq2[T1, T2] {
-	return func(yield func(T1, T2) bool) bool {
-		return seq(func(v Pair[T1, T2]) bool {
+	return func(yield func(T1, T2) bool) {
+		seq(func(v Pair[T1, T2]) bool {
 			return yield(v.Split())
 		})
 	}

--- a/source.go
+++ b/source.go
@@ -12,10 +12,10 @@ import (
 // returned Seq does not end. To limit it to a specific number of
 // returned elements, use [Limit].
 func Generate[T Addable](start, step T) Seq[T] {
-	return func(yield func(T) bool) bool {
+	return func(yield func(T) bool) {
 		for {
 			if !yield(start) {
-				return false
+				return
 			}
 			start += step
 		}
@@ -36,40 +36,40 @@ func OfSlice[T any, S ~[]T](s S) Seq[T] {
 // OfSliceIndex returns a Seq over the elements of s. It is equivalent
 // to range s.
 func OfSliceIndex[T any, S ~[]T](s S) Seq2[int, T] {
-	return func(yield func(int, T) bool) bool {
+	return func(yield func(int, T) bool) {
 		for i, v := range s {
 			if !yield(i, v) {
-				return false
+				return
 			}
 		}
-		return false
+		return
 	}
 }
 
 // Bytes returns a Seq over the bytes of s.
 func Bytes(s string) Seq[byte] {
-	return func(yield func(byte) bool) bool {
+	return func(yield func(byte) bool) {
 		for i := 0; i < len(s); i++ {
 			if !yield(s[i]) {
-				return false
+				return
 			}
 		}
-		return false
+		return
 	}
 }
 
 // Runes returns a Seq over the runes of s.
 func Runes[T ~[]byte | ~string](s T) Seq[rune] {
-	return func(yield func(rune) bool) bool {
+	return func(yield func(rune) bool) {
 		b := unsafe.Slice(unsafe.StringData(*(*string)(unsafe.Pointer(&s))), len(s))
 		for len(b) > 0 {
 			r, size := utf8.DecodeRune(b)
 			if !yield(r) {
-				return false
+				return
 			}
 			b = b[size:]
 		}
-		return false
+		return
 	}
 }
 
@@ -80,14 +80,15 @@ func StringSplit(s, sep string) Seq[string] {
 		return Map(Runes(s), func(c rune) string { return string(c) })
 	}
 
-	return func(yield func(string) bool) bool {
+	return func(yield func(string) bool) {
 		for {
 			m := strings.Index(s, sep)
 			if m < 0 {
-				return yield(s)
+				yield(s)
+				return
 			}
 			if !yield(s[:m]) {
-				return false
+				return
 			}
 			s = s[m+len(sep):]
 		}
@@ -96,13 +97,13 @@ func StringSplit(s, sep string) Seq[string] {
 
 // OfMap returns a Seq over the key-value pairs of m.
 func OfMap[K comparable, V any, M ~map[K]V](m M) Seq2[K, V] {
-	return func(yield func(K, V) bool) bool {
+	return func(yield func(K, V) bool) {
 		for k, v := range m {
 			if !yield(k, v) {
-				return false
+				return
 			}
 		}
-		return false
+		return
 	}
 }
 
@@ -119,8 +120,8 @@ func MapValues[K comparable, V any, M ~map[K]V](m M) Seq[V] {
 // ToPair takes a two-value iterator and produces a single-value
 // iterator of pairs.
 func ToPair[T1, T2 any](seq Seq2[T1, T2]) Seq[Pair[T1, T2]] {
-	return func(yield func(Pair[T1, T2]) bool) bool {
-		return seq(func(v1 T1, v2 T2) bool {
+	return func(yield func(Pair[T1, T2]) bool) {
+		seq(func(v1 T1, v2 T2) bool {
 			return yield(P(v1, v2))
 		})
 	}
@@ -128,8 +129,8 @@ func ToPair[T1, T2 any](seq Seq2[T1, T2]) Seq[Pair[T1, T2]] {
 
 // V1 returns a Seq which iterates over only the T1 elements of seq.
 func V1[T1, T2 any](seq Seq2[T1, T2]) Seq[T1] {
-	return func(yield func(T1) bool) bool {
-		return seq(func(v1 T1, v2 T2) bool {
+	return func(yield func(T1) bool) {
+		seq(func(v1 T1, v2 T2) bool {
 			return yield(v1)
 		})
 	}
@@ -137,8 +138,8 @@ func V1[T1, T2 any](seq Seq2[T1, T2]) Seq[T1] {
 
 // V2 returns a Seq which iterates over only the T2 elements of seq.
 func V2[T1, T2 any](seq Seq2[T1, T2]) Seq[T2] {
-	return func(yield func(T2) bool) bool {
-		return seq(func(v1 T1, v2 T2) bool {
+	return func(yield func(T2) bool) {
+		seq(func(v1 T1, v2 T2) bool {
 			return yield(v2)
 		})
 	}
@@ -147,27 +148,27 @@ func V2[T1, T2 any](seq Seq2[T1, T2]) Seq[T2] {
 // OfChan returns a Seq which yields values received from c. The
 // sequence ends when c is closed. It is equivalent to range c.
 func OfChan[T any](c <-chan T) Seq[T] {
-	return func(yield func(T) bool) bool {
+	return func(yield func(T) bool) {
 		for v := range c {
 			if !yield(v) {
-				return false
+				return
 			}
 		}
-		return false
+		return
 	}
 }
 
 // RecvContext returns a Seq that receives from c continuously until
 // either c is closed or the given context is canceled.
 func RecvContext[T any](ctx context.Context, c <-chan T) Seq[T] {
-	return func(yield func(T) bool) bool {
+	return func(yield func(T) bool) {
 		for {
 			select {
 			case <-ctx.Done():
-				return false
+				return
 			case v, ok := <-c:
 				if !ok || !yield(v) {
-					return false
+					return
 				}
 			}
 		}

--- a/transform_test.go
+++ b/transform_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMap(t *testing.T) {
 	s := OfSlice([]int{1, 2, 3})
-	n := Collect(Map(s, func(v int) float64 { return float64(v*2) }))
+	n := Collect(Map(s, func(v int) float64 { return float64(v * 2) }))
 	if [3]float64(n) != [...]float64{2, 4, 6} {
 		t.Fatal(n)
 	}
@@ -155,10 +155,10 @@ func TestSplit2(t *testing.T) {
 
 func TestCache(t *testing.T) {
 	var i int
-	f := func(yield func(int) bool) bool {
+	f := func(yield func(int) bool) {
 		yield(i)
 		i++
-		return false
+		return
 	}
 	seq := Cache(f)
 	if s := Collect(seq); !slices.Equal(s, []int{0}) {

--- a/xiter.go
+++ b/xiter.go
@@ -10,15 +10,15 @@ import "sync"
 // to a break statement. The return value of the Seq function itself
 // is completely ignored, but present to be compatible with the CL
 // 510541 prototype.
-type Seq[T any] func(yield func(T) bool) bool
+type Seq[T any] func(yield func(T) bool)
 
 // A SplitSeq is like a Seq but can yield via either of two functions.
 // It might not be useful, but is included anyways because it might
 // be.
-type SplitSeq[T1, T2 any] func(y1 func(T1) bool, y2 func(T2) bool) bool
+type SplitSeq[T1, T2 any] func(y1 func(T1) bool, y2 func(T2) bool)
 
 // Seq2 represents a two-value iterator.
-type Seq2[T1, T2 any] func(yield func(T1, T2) bool) bool
+type Seq2[T1, T2 any] func(yield func(T1, T2) bool)
 
 // Pair contains two values of arbitrary types.
 type Pair[T1, T2 any] struct {


### PR DESCRIPTION
If this suits you, this changes the code to match the latest implementation from the proposal, and what is now available under GOXPERIMENT=range in the 1.22 dev Go toolchain.
